### PR TITLE
Support for Chrome, IE and Edge

### DIFF
--- a/dist/cropme.css
+++ b/dist/cropme.css
@@ -9,17 +9,21 @@
  */
 .cropme-wrapper {
   width: 100%;
-  height: 100%; }
+  height: 100%;
+}
 
 .cropme-container {
   position: relative;
   overflow: hidden;
-  margin: 0 auto; }
-  .cropme-container img {
-    width: initial !important;
-    cursor: move;
-    opacity: 0;
-    touch-action: none; }
+  margin: 0 auto;
+}
+
+.cropme-container img {
+  width: initial !important;
+  cursor: move;
+  opacity: 0;
+  touch-action: none; 
+}
 
 #img {
   border: 5px solid #f00; }
@@ -35,26 +39,20 @@
   left: 0;
   box-shadow: 0 0 2000px 2000px rgba(0, 0, 0, 0.5);
   z-index: 0;
-  pointer-events: none; }
-  .viewport.circle {
-    border-radius: 50%; }
+  pointer-events: none; 
+}
 
-.cropme-slider, .cropme-rotation-slider {
-  text-align: center; }
-  .cropme-slider input, .cropme-rotation-slider input {
-    -webkit-appearance: none; }
-    .cropme-slider input:disabled, .cropme-rotation-slider input:disabled {
-      opacity: 0.5; }
-    .cropme-slider input::-webkit-slider-runnable-track, .cropme-rotation-slider input::-webkit-slider-runnable-track {
-      height: 3px;
-      background: rgba(0, 0, 0, 0.5);
-      border-radius: 3px; }
-    .cropme-slider input::-webkit-slider-thumb, .cropme-rotation-slider input::-webkit-slider-thumb {
-      -webkit-appearance: none;
-      height: 16px;
-      width: 16px;
-      border-radius: 50%;
-      background: #ddd;
-      margin-top: -6px; }
-    .cropme-slider input:focus, .cropme-rotation-slider input:focus {
-      outline: none; }
+.viewport.circle {
+  border-radius: 50%; 
+}
+
+.cropme-slider, 
+.cropme-rotation-slider {
+  text-align: center; 
+}
+
+.cropme-slider input[type=range]::-ms-tooltip, 
+.cropme-rotation-slider input[type=range]::-ms-tooltip {
+  display: none; 
+}
+

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1 user-scalable=no">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge,chrome=1">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.2.1/css/bootstrap.min.css"
         crossorigin="anonymous">
     <link rel="stylesheet" href="css/style.css">
@@ -184,6 +184,7 @@
             </div>
         </div>
     </section>
+	<script src="https://cdn.jsdelivr.net/npm/promise-polyfill@8/dist/polyfill.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue@2.5.21/dist/vue.js"></script>
     <script src="dist/cropme.js"></script>
     <script src="js/app.js"></script>

--- a/js/app.js
+++ b/js/app.js
@@ -35,40 +35,40 @@ new Vue({
   },
   watch: {
     options: {
-      handler(val) {
+      handler: function(val) {
         this.cropme.reload(val)
       },
       deep: true
     }
   },
-  created() {
+  created: function() {
     this.options = JSON.parse(JSON.stringify(this.defaultOptions))
   },
-  mounted() {
+  mounted: function() {
     this.init()
   },
   methods: {
-    init() {
+    init: function() {
       this.el = document.getElementById('cropme')
       this.cropme = new Cropme(this.el, this.options)
       this.cropme.bind({
         url: 'images/pic.jpeg',
       })
     },
-    getPosition() {
+    getPosition: function() {
       this.position = this.cropme.position()
       $('#cropmePosition').modal()
     },
-    crop() {
+    crop: function() {
       let img = document.getElementById('cropme-result')
       this.cropme.crop({
         width: 600
-      }).then(res => {
+      }).then(function(res) {
         img.src = res
         $('#cropmeModal').modal()
       })
     },
-    reset() {
+    reset: function() {
       this.options = JSON.parse(JSON.stringify(this.defaultOptions))
       this.cropme.destroy()
       this.init()


### PR DESCRIPTION
Thanks for nice lib and clean code!

I found some browser compatibility issues and made some hacks to demonstrate possible solutions... but it definitely needs some cosmetics :)

- IE and chrome don't respect those range sliders CSS:
  Since example page already using 'twitter-bootstrap/4.2.1' why not replacing current implementation of input/rage/sliders CSS with existing bootstrap class called 'custom-range' that handles most browsers?
  Probably 'custom-range' class should be duplicated from Bootstrap into cropme.css to support developers who don't use bootstrap in their projects. I also added css hack to hide range tooltips in IE.

- IE and Edge image.getBoundingClientRect() returns ClientRect instead of DOMRect:
  this causes '.crop()' function to return an empty image, because ClientRect doesn't have 'x' and 'y'.
  see https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect

- IE and Edge to support range sliders events:
  I tested on IE11 and it triggers 'change' instead of 'input' so sliders don't react on user input.

- IE to support Promise:
  There are lots of polyfills that make Promise available on IE... I'm using 
  https://github.com/taylorhakes/promise-polyfill 
  as an example, but probably it would be better to wrap it into "poNyfill" because devs may have other implementations too.

- IE doesn't have Object.assign:
  I'm using a recommended polyfill from 
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill

- IE prefers ES5 functions:
  { foo: function(){} }